### PR TITLE
Property test; set followed by contains is always true

### DIFF
--- a/corral.json
+++ b/corral.json
@@ -2,12 +2,8 @@
   "packages": [],
   "deps": [
     {
-      "locator": "ponylang/ponycheck",
-      "version": "0.5.4"
-    },
-    {
       "locator": "github.com/ponylang/ponycheck.git",
-      "version": ""
+      "version": "0.5.4"
     }
   ],
   "info": {

--- a/corral.json
+++ b/corral.json
@@ -1,9 +1,21 @@
 {
+  "packages": [],
   "deps": [
     {
       "locator": "ponylang/ponycheck",
       "version": "0.5.4"
+    },
+    {
+      "locator": "github.com/ponylang/ponycheck.git",
+      "version": ""
     }
   ],
-  "info": {}
+  "info": {
+    "description": "",
+    "homepage": "",
+    "license": "",
+    "documentation_url": "",
+    "version": "",
+    "name": ""
+  }
 }

--- a/lock.json
+++ b/lock.json
@@ -1,10 +1,6 @@
 {
   "locks": [
     {
-      "locator": "ponylang/ponycheck",
-      "revision": ""
-    },
-    {
       "locator": "github.com/ponylang/ponycheck.git",
       "revision": ""
     }

--- a/lock.json
+++ b/lock.json
@@ -1,7 +1,12 @@
 {
   "locks": [
     {
-      "locator": "ponylang/ponycheck"
+      "locator": "ponylang/ponycheck",
+      "revision": ""
+    },
+    {
+      "locator": "github.com/ponylang/ponycheck.git",
+      "revision": ""
     }
   ]
 }

--- a/roaring/_test.pony
+++ b/roaring/_test.pony
@@ -1,6 +1,6 @@
 use "ponytest"
 
-primitive PrivateTests is TestList
+primitive PrivateRoaringTests is TestList
   fun tag tests(test: PonyTest) =>
     """
     This is the place for tests of

--- a/roaring/_util.pony
+++ b/roaring/_util.pony
@@ -3,8 +3,8 @@ primitive _Bits
   Primitive for having a single source of truth for when we un-assume endianness
   """
 
-  fun mostsig(value: U32): U16 => (value >> (value.bitwidth() / 2)).u16()
-  fun address(value: U32): U16 => mostsig(value)
+  fun most_sig(value: U32): U16 => (value >> (value.bitwidth() / 2)).u16()
+  fun address(value: U32): U16 => most_sig(value)
 
-  fun leastsig(value: U32): U16 => value.u16()
-  fun storable(value: U32): U16 => leastsig(value)
+  fun least_sig(value: U32): U16 => value.u16()
+  fun storable(value: U32): U16 => least_sig(value)

--- a/roaring/test/main.pony
+++ b/roaring/test/main.pony
@@ -1,4 +1,5 @@
 use "ponytest"
+use "ponycheck"
 use ".."
 
 actor Main is TestList
@@ -10,9 +11,10 @@ actor Main is TestList
     // register test cases to run here
     test(DummyTest)
     test(SetTest)
+    test(Property1UnitTest[U32](SetContains))
 
     // include the tests of the private API here
-    PrivateTests.tests(test)
+    PrivateRoaringTests.tests(test)
 
 class iso DummyTest is UnitTest
   fun name(): String => "public dummy"
@@ -31,3 +33,13 @@ class iso SetTest is UnitTest
     h.assert_true(roaring.set(U32(2)))
     h.assert_false(roaring.set(U32(0)))
     h.assert_false(roaring.set(U32.max_value()))
+
+class SetContains is Property1[U32]
+  fun name(): String => "Bitmaps contains values after set"
+
+  fun gen(): Generator[U32] => Generators.u32(U32.min_value(), U32.max_value())
+
+  fun property(arg1: U32, h: PropertyHelper) =>
+    let roaring = Roaring
+    roaring.set(arg1)
+    h.assert_true(roaring.contains(arg1))

--- a/roaring/test/main.pony
+++ b/roaring/test/main.pony
@@ -9,37 +9,62 @@ actor Main is TestList
 
   fun tag tests(test: PonyTest) =>
     // register test cases to run here
-    test(DummyTest)
-    test(SetTest)
     test(Property1UnitTest[U32](SetContains))
+    test(Property1UnitTest[U32](SetTwice))
+    test(Property1UnitTest[Array[U32]](MediumArraySetContains))
+    test(Property1UnitTest[Array[U32]](MediumArraySetTwice))
 
     // include the tests of the private API here
     PrivateRoaringTests.tests(test)
 
-class iso DummyTest is UnitTest
-  fun name(): String => "public dummy"
-
-  fun apply(h: TestHelper) =>
-    h.assert_eq[USize](1, 1)
-
-class iso SetTest is UnitTest
-  fun name(): String => "set"
-
-  fun apply(h: TestHelper) =>
-    let roaring = Roaring
-    h.assert_false(roaring.set(U32(1)))
-    h.assert_true(roaring.set(U32(1)))
-    h.assert_false(roaring.set(U32(2)))
-    h.assert_true(roaring.set(U32(2)))
-    h.assert_false(roaring.set(U32(0)))
-    h.assert_false(roaring.set(U32.max_value()))
-
 class SetContains is Property1[U32]
-  fun name(): String => "Bitmaps contains values after set"
+  fun name(): String => "contains() is true after set()"
 
   fun gen(): Generator[U32] => Generators.u32(U32.min_value(), U32.max_value())
 
   fun property(arg1: U32, h: PropertyHelper) =>
     let roaring = Roaring
-    roaring.set(arg1)
-    h.assert_true(roaring.contains(arg1))
+    h.assert_false(roaring.contains(arg1))  // Not much good as a test if true here
+    h.assert_false(roaring.set(arg1))  // Value not previously set
+    h.assert_true(roaring.contains(arg1))  // Does contain value
+
+class SetTwice is Property1[U32]
+  fun name(): String => "set() returns status of if previously set()"
+
+  fun gen(): Generator[U32] => Generators.u32(U32.min_value(), U32.max_value())
+
+  fun property(arg1: U32, h: PropertyHelper) =>
+    let roaring = Roaring
+    h.assert_false(roaring.set(arg1))  // Value not previously set
+    h.assert_true(roaring.set(arg1))  // Value previously set
+
+class MediumArraySetContains is Property1[Array[U32]]
+  fun name(): String => "Medium-sized array; contains() is true after set()"
+
+  fun gen(): Generator[Array[U32]] => GenerateMediumArray()
+
+  fun property(arg1: Array[U32], h: PropertyHelper) =>
+    let roaring = Roaring
+    for value in arg1.values() do
+      roaring.set(value)  // Set value (may have been previously set)
+      h.assert_true(roaring.contains(value))  // Does contain value
+    end
+
+class MediumArraySetTwice is Property1[Array[U32]]
+  fun name(): String => "Medium-sized array; set() returns status of if previously set()"
+
+  fun gen(): Generator[Array[U32]] => GenerateMediumArray()
+
+  fun property(arg1: Array[U32], h: PropertyHelper) =>
+    let roaring = Roaring
+    for value in arg1.values() do
+      roaring.set(value)  // Set value (may have been previously set)
+      h.assert_true(roaring.set(value))  // Value previously set
+    end
+
+primitive GenerateMediumArray
+  fun apply(): Generator[Array[U32]] =>
+    Generators.array_of[U32](where
+        gen = Generators.u32(U32.min_value(), U32.max_value()),
+        min = 4096.mul(2),
+        max = 4096.mul(4))


### PR DESCRIPTION
Not sure if there is a more idiomatic way to use ponycheck, but this marks the first non-stdlib addition and required a renaming of `PrivateTests` to `PrivateRoaringTests` due to a name clash with ponycheck itself. (I decided aliasing was not as clean as desired for something so small anyhow.)