### PR TITLE
Medium-sized unique arrays

### DIFF
--- a/roaring/test/main.pony
+++ b/roaring/test/main.pony
@@ -82,7 +82,7 @@ primitive GenerateMediumUniqueArray
   fun apply(): Generator[Array[U32]] =>
     let min: USize = 4096.mul(2)
     let max: USize = 4096.mul(4)
-    let hashset: Generator[HashSet[U32, HashEq[U32] val] ref] box =
+    let hashset =
       Generators.set_of[U32](where
         gen = Generators.u32(U32.min_value(), U32.max_value()),
         max = max

--- a/roaring/test/main.pony
+++ b/roaring/test/main.pony
@@ -41,30 +41,59 @@ class SetTwice is Property1[U32]
 class MediumArraySetContains is Property1[Array[U32]]
   fun name(): String => "Medium-sized array; contains() is true after set()"
 
-  fun gen(): Generator[Array[U32]] => GenerateMediumArray()
+  fun gen(): Generator[Array[U32]] => GenerateMediumUniqueArray()
 
   fun property(arg1: Array[U32], h: PropertyHelper) =>
     let roaring = Roaring
     for value in arg1.values() do
-      roaring.set(value)  // Set value (may have been previously set)
+      h.assert_false(roaring.contains(value))  // Not much good as a test if true here
+      h.assert_false(roaring.set(value))  // Value not previously set
       h.assert_true(roaring.contains(value))  // Does contain value
     end
 
 class MediumArraySetTwice is Property1[Array[U32]]
   fun name(): String => "Medium-sized array; set() returns status of if previously set()"
 
-  fun gen(): Generator[Array[U32]] => GenerateMediumArray()
+  fun gen(): Generator[Array[U32]] => GenerateMediumUniqueArray()
 
   fun property(arg1: Array[U32], h: PropertyHelper) =>
     let roaring = Roaring
     for value in arg1.values() do
-      roaring.set(value)  // Set value (may have been previously set)
+      h.assert_false(roaring.set(value))  // Value not previously set
       h.assert_true(roaring.set(value))  // Value previously set
     end
 
 primitive GenerateMediumArray
   fun apply(): Generator[Array[U32]] =>
     Generators.array_of[U32](where
+      gen = Generators.u32(U32.min_value(), U32.max_value()),
+      min = 4096.mul(2),
+      max = 4096.mul(4))
+
+primitive GenerateMediumUniqueArray
+  """
+  Generate a medium-sized array of unique U32 values.
+
+  TODO: This currently uses a post-fact filter for minimum size which results in
+  longer runtimes to produce a properly sized array. A faster procedure is desired.
+  One possible route is using collections.Range(U32.min_value(), U32.max_value(), <non-looping step size>)
+  followed by a random.shuffle(array)
+  """
+  fun apply(): Generator[Array[U32]] =>
+    let min: USize = 4096.mul(2)
+    let max: USize = 4096.mul(4)
+    let hashset: Generator[HashSet[U32, HashEq[U32] val] ref] box =
+      Generators.set_of[U32](where
         gen = Generators.u32(U32.min_value(), U32.max_value()),
-        min = 4096.mul(2),
-        max = 4096.mul(4))
+        max = max
+      )
+    hashset
+      .filter({ (set) => (set, (min <= set.size())) })
+      .map[Array[U32]]({ 
+        (set) => 
+          let array: Array[U32] = Array[U32].create(set.size())
+          for value in set.values() do
+            array.push(value)
+          end
+          array
+      })


### PR DESCRIPTION
Following a [conversation with Matthias on Zulip](https://ponylang.zulipchat.com/#narrow/stream/190363-projects/topic/RoaringBitmap/near/232784064), I use the `set_of` generator then filter for the set being at least a minimum size then convert it to an array so the existing code did not need to change. I made a TODO for a possible way to produce a faster generator for our purposes -- I tried my hand at implementing, but had little luck. 

I did change the corresponding proptests to now consider the uniqueness to our advantage.